### PR TITLE
News gallery and card rb 3 try of most popular access 

### DIFF
--- a/src/js/gallery-news-render.js
+++ b/src/js/gallery-news-render.js
@@ -15,7 +15,7 @@ async function onLoadNewsPage() {
   try { 
     newsGalleryLnk.innerHTML = '';
     const data = await galleryFetchPopular(currentPage);
-    console.log(data);
+    console.log(data.data);
   }
   catch (e) { 
     console.log(e.message);

--- a/src/js/gallery-news-render.js
+++ b/src/js/gallery-news-render.js
@@ -14,8 +14,8 @@ onLoadNewsPage();
 async function onLoadNewsPage() { 
   try { 
     newsGalleryLnk.innerHTML = '';
-    const data = await galleryFetchPopular(currentPage);
-    console.log(data.data);
+    const dataResponse = await galleryFetchPopular(currentPage);
+    console.log(dataResponse.data.results);
   }
   catch (e) { 
     console.log(e.message);
@@ -98,40 +98,25 @@ async function readDataArrayToMarcup(articlesArray) {
     `; 
   }).join('');
 }
-/*
-export async function readDataArrayToMarcup(hitsArray) {
-  //previewURL
-  return await hitsArray
-    .map(
-      ({
-        largeImageURL,
-        webformatURL,
-        tags,
-        likes,
-        views,
-        comments,
-        downloads,
-      }) => {
-        return `<a class="gallery__item" href="${largeImageURL}"><div class="photo-card">
-  <div class="photo-container"><img src="${webformatURL}" alt="${tags}" loading="lazy" /></div>
-  <div class="info">
-    <p class="info-item">
-      <b>Likes ${likes}</b>
-    </p>
-    <p class="info-item">
-      <b>Views ${views}</b>
-    </p>
-    <p class="info-item">
-      <b>Comments ${comments}</b>
-    </p>
-    <p class="info-item">
-      <b>Downloads ${downloads}</b>
-    </p>
-  </div>
-</div></a>`;
-      }
-    )
-    .join('');
-}
 
+
+/*
+const key = "E0X3jomXcp5AQytChJb6iragE7Tjdw0j";
+const api = "https://api.nytimes.com/svc/search/v2/articlesearch.json?";
+function fetchNews(keyword) {
+  return fetch(`${api}q=${keyword}&api-key=${key}`)
+    .then((resolve) => {
+      return resolve.json();
+    })
+    .then((news) =>
+      console.log(
+        "http://www.nytimes.com/" + news.response.docs[0].multimedia[0].url
+      )
+    );
+}
+fetchNews("cat");
+*/
+
+/*
+https://github.com/nytimes/public_api_specs/issues/52
 */

--- a/src/js/gallery-news-render.js
+++ b/src/js/gallery-news-render.js
@@ -1,4 +1,5 @@
 import { galleryFetch } from './galley-news-fetch';
+import { galleryFetchPopular } from './galley-news-fetch';
 
 const searchForm = document.querySelector(".search-form");
 const newsGalleryLnk = document.querySelector(".news-gallery");
@@ -8,6 +9,18 @@ let currentHits = 0;
 let globalSearchQuery = '';
 
 searchForm.addEventListener('submit', onSearchBtn);
+onLoadNewsPage();
+
+async function onLoadNewsPage() { 
+  try { 
+    newsGalleryLnk.innerHTML = '';
+    const data = await galleryFetchPopular(currentPage);
+    console.log(data);
+  }
+  catch (e) { 
+    console.log(e.message);
+  }
+}
 
 function onSearchBtn(e) { 
     e.preventDefault();

--- a/src/js/galley-news-fetch.js
+++ b/src/js/galley-news-fetch.js
@@ -2,10 +2,11 @@ const axios = require('axios').default;
 //https://api.nytimes.com/svc/search/v2/articlesearch.json?q=panther&api-key=r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR
 
 const BASE_URL = 'https://api.nytimes.com/svc/search/v2/articlesearch.json?q=';
-const BASE_POPULAR_URL = 'https://api.nytimes.com/svc/mostpopular/v2/viewed/1.json?api-key=';
+const KEY = 'r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR';
+const BASE_POPULAR_URL = `https://api.nytimes.com/svc/mostpopular/v2/viewed/30.json?api-key=${KEY}`;
 //https://api.nytimes.com/svc/mostpopular/v2/emailed/7.json?api-key=r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR
 //https://api.nytimes.com/svc/mostpopular/v2/viewed/1.json?api-key=r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR
-const KEY = 'r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR';
+
 let PER_PAGE = 40;
 
 export async function galleryFetch(queryLine, currentPage) { 
@@ -35,7 +36,7 @@ export async function galleryFetch(queryLine, currentPage) {
 export async function galleryFetchPopular(currentPage) { 
 
     try {
-        let response = await axios.get(`BASE_POPULAR_URL${KEY}`);
+        let response = await axios.get(BASE_POPULAR_URL);
         console.log("response", response);
         return response;
     }

--- a/src/js/galley-news-fetch.js
+++ b/src/js/galley-news-fetch.js
@@ -2,6 +2,9 @@ const axios = require('axios').default;
 //https://api.nytimes.com/svc/search/v2/articlesearch.json?q=panther&api-key=r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR
 
 const BASE_URL = 'https://api.nytimes.com/svc/search/v2/articlesearch.json?q=';
+const BASE_POPULAR_URL = 'https://api.nytimes.com/svc/mostpopular/v2/viewed/1.json?api-key=';
+//https://api.nytimes.com/svc/mostpopular/v2/emailed/7.json?api-key=r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR
+//https://api.nytimes.com/svc/mostpopular/v2/viewed/1.json?api-key=r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR
 const KEY = 'r45Ed0pk3C31WWBJaP0BSBDVSCCTnWUR';
 let PER_PAGE = 40;
 
@@ -22,6 +25,19 @@ export async function galleryFetch(queryLine, currentPage) {
             }
         ); */
         return response.data.response;
+    }
+    catch (e) { 
+        console.log(e.message);
+    }
+
+}
+
+export async function galleryFetchPopular(currentPage) { 
+
+    try {
+        let response = await axios.get(`BASE_POPULAR_URL${KEY}`);
+        console.log("response", response);
+        return response;
     }
     catch (e) { 
         console.log(e.message);


### PR DESCRIPTION
Запит до "найбільш популярних"
const BASE_POPULAR_URL = `https://api.nytimes.com/svc/mostpopular/v2/viewed/30.json?api-key=${KEY}`;

при завантаженні сторінки.
Дуже ускладнений і відмінний від попереднього json та вміст елемента масиву.